### PR TITLE
Fix to bug that was allowing user to enter in a past date

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -273,12 +273,14 @@ let displaySumbittedEstimate = () => {
   let selectedDestination = allDestinations.find((destination) => {
     return parseInt(destinationPicker.value) === destination.id
   })
-  let currentTrip = new Trips(captureSubmitedData())
-  currentTrip.calculatePrice(allDestinations)
-  submitedTripPrice.innerText =
-    `  Your Adventure to ${selectedDestination.destination} is estimated cost is
-        $${currentTrip.price.toFixed(2)} Clink Submit to request!
-    `
+  if(captureSubmitedData() !== undefined) {
+    let currentTrip = new Trips(captureSubmitedData())
+    currentTrip.calculatePrice(allDestinations)
+    submitedTripPrice.innerText =
+      `  Your Adventure to ${selectedDestination.destination} is estimated cost is
+          $${currentTrip.price.toFixed(2)} Clink Submit to request!
+      `
+  }
 }
 
 let successfullSubmitMessage = (response) => {

--- a/src/index.js
+++ b/src/index.js
@@ -237,15 +237,23 @@ let populateAllPages = () => {
 let captureSubmitedData = () => {
   let calenderDate = calenderPicker.value.split("-")
   let formatedDate = calenderDate.join("/")
-  return {
-    id: Date.now(),
-    userID: currentTraveler.id,
-    destinationID: parseInt(destinationPicker.value),
-    travelers: parseInt(travelersNumberPicker.value),
-    date: formatedDate,
-    duration: parseInt(travelersDurationPicker.value),
-    status: 'pending',
-    suggestedActivities: []
+  let currentDay = new Date(Date.now())
+  let calenderCheck = new Date(formatedDate)
+  if (calenderCheck > currentDay) {
+    return {
+      id: Date.now(),
+      userID: currentTraveler.id,
+      destinationID: parseInt(destinationPicker.value),
+      travelers: parseInt(travelersNumberPicker.value),
+      date: formatedDate,
+      duration: parseInt(travelersDurationPicker.value),
+      status: 'pending',
+      suggestedActivities: []
+    }
+  } else {
+    submitEstimate.classList.remove("hidden");
+    submitTrip.classList.add("hidden");
+    alert("You have entered an invailed date please try again")
   }
 }
 


### PR DESCRIPTION
# Pull Request Travel-Tracker



#### What’s this PR do?

* This set-up a checker to see if the date is an invalid entry and provides an alert if invalid   

#### Where should the reviewer start?

* Reviewer should start with the index.js

#### How should this be manually tested?

* open the application up in localhost then run a past date and attempt to submit it 

#### Any background context you want to provide?

* This was a known issue and it has now been resolved (however the user is still allowed to select the next day)  

#### What are the relevant tickets?

* bug with calendar 

#### Screenshots (if appropriate):

* none at this time 

#### Questions:

* none at this time 